### PR TITLE
Update: replace more then first occurence

### DIFF
--- a/mb2md.pl
+++ b/mb2md.pl
@@ -761,7 +761,7 @@ sub convertit
 	# Strip destination directory extension	if requested
 	defined($strip_dir_ext) && ($destinationdir =~ s/\.$strip_dir_ext$//);
 	# Also strip directory extension from all ancestors
-	defined($strip_dir_ext) && ($temppath =~ s/\.$strip_dir_ext\//\//);
+	defined($strip_dir_ext) && ($temppath =~ s/\.$strip_dir_ext\//\//g);
 	defined($strip_dir_ext) && ($temppath =~ s/\.$strip_dir_ext$//);
 
 	# We don't want to have .'s in the $targetfile file


### PR DESCRIPTION
for strip_dir_ext:

If your folder structure has more then one subfolder, only the first occurrence of the dir ext will be stripped. The regex modified "g" will replace all matches.